### PR TITLE
readme_content_update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,137 +13,16 @@ Currently, Chargebee offer SPIs for the following capabilities:
 These SPIs allow partners to build custom adapters by implementing the SPI-defined endpoints. The detailed OpenAPI specifications for these SPIs can be found in the spec/spi folder of the repository.
 
 ## Setup with Mintlify
-- Chargebee uses Mintlify tool to host the SPI docs. Please follow the below steps to setup locally.
 
-#### 1. Install the Mintlify CLI
-- Install the Mintlify CLI globally using npm:
-
-```bash
-    npm i -g mintlify
-```
-
-#### 2. Run Local Development Server
-- For local preview of documentation run below command:
-
-```bash
-    mintlify dev
-```
-
+For detailed instructions, check out the [Local Setup](docs/localsetup.md).
 
 ## Steps to Add or Update a SPI Using OpenAPI Specification
 
-#### 1. Modify the OpenAPI Specification
-
-#### 1.1 Update an Existing SPI
-- Edit the corresponding OpenAPI specification file to update the SPI.  
-  **Example:** Modify a parameter in the `tax-estimate` endpoint located in `spec/spi/open_tax.yml`.
-
-#### 1.2 Add a New SPI to an Existing OpenAPI Specification
-- Append the new SPI endpoint to the relevant OpenAPI specification file.  
-  **Example:** Add a new endpoint `check/taxability` in `spec/spi/open_tax.yml`.
-
-#### 1.3 Add a New SPI in a New OpenAPI Specification
-- Create a new OpenAPI specification file named `openapi_<capability_name>.yml` inside the `spec/spi/` directory.  
-  **Example:** `spec/spi/openapi_tax.yml`.
-- Update the [spec.config](spec.config) file to include the new file configuration.
-
-
-#### 2. Validate the OpenAPI Specification
-- Use the following command to validate a **specific** OpenAPI specification
-  ```bash
-  sh gradlew validateSpec_tax --warning-mode all --stacktrace
-  ```
-
-- Use the following command to validate all the OpenAPI specs:
-  ```bash
-  sh gradlew validateSpec  --warning-mode all --stacktrace  
-  ```
-
-#### 3. Generate the Bundled OpenAPI spec & related files
-- Each OpenAPI specification file in the spec/spi directory may reference other specification files (e.g., credentials.yml).
-  To generate a single bundled OpenAPI specification, use the following commands:
-  - for a specific openAPI spec:
-  ```bash
-  sh gradlew generateSpec_tax --warning-mode all --stacktrace
-  ```
-
-  - for all openAPI specs:
-  ```bash
-  sh gradlew generateSpec  --warning-mode all --stacktrace
-  ```
-
-- The generated output will include:
-  - Java Models
-  - Clients
-  - Markdown files
-
-- These files will be located in the `generated/<capability_name>` folder. **Example:** `generated/tax`
-
-#### 4. Generate SPI jar
-- To build the SPI jar for Java, use the following command:
-  ```bash
-  sh gradlew build
-  ```
-- The generated SPI jar will be located in the `./build/libs/` directory.
-
-#### 5. Update postman collection
-- Refer to the [Updating & Using Postman Collection (TO BE ADDED)](#updating--using-postman-collection-to-be-added) section to follow the steps to update the Postman collection.
-
+For detailed instructions, check out the [Add or Update a SPI](docs/add_update_spi.md).
 
 ## Steps to update mintlify’s files for creating a SPI endpoint or new openAPISpec
 
-#### Prerequisites
-
-#### 1. Install Node.js and npm
-- Node.js and npm are required to run the Mintlify CLI.    
-
-#### 2. Install Mintlify CLI
-- Install the Mintlify CLI globally to manage documentation and generate .mdx files:
-  ```bash
-  npm i -g mintlify
-  ```
-
-#### 1. Generate mdx files for SPI endpoint or new openAPISpec
-- Use the following command to create mdx files for the endpoints from the openAPI spec file you have added or made changes to
-  ```bash
-  npx @mintlify/scraping@latest openapi-file <path-to-openapi-file> -o api-reference
-  ```
-  **Example:**
-  ```bash
-  npx @mintlify/scraping@latest openapi-file ./spec/spi/openapi_tax.yml -o api-reference
-  ```
-
-#### 2. Add reference to generated endpoint mdx files in navigation section of mint.json
-
-#### 2.1 Locate Generated MDX Files
-After running the mdx files generation command, check the api-reference directory for new MDX files.
-
-#### 2.2 Update mint.json Navigation
-```json
-{
-  "navigation": [
-    {
-      "group": "API Reference",
-      "pages": [
-        // Existing pages
-        "api-reference/existing-endpoint",
-        
-        // Add your new endpoint MDX file here
-        "api-reference/new-endpoint-file"
-      ]
-    }
-  ]
-}
-```
-#### Note
-1. Don't use full file paths. Use relative paths.
-2. Don't include the .mdx extension.
-
-#### 3. Preview the changes locally
-- Run the following command to preview the changes locally
-  ```bash
-  mintlify dev
-  ```
+For detailed instructions, check out the [Update Mintlify Files](docs/mintlify_files.md).
 
 <!--
 ## Getting Started
@@ -218,14 +97,7 @@ Example:
 ```
 
 ## Steps to follow release(Chargebee owned)
-1. Assume release is 0.0.9. (find release from git page release section)
-2. create a new branch called release/<release> so this would be release/0.0.9
-3. create new branch for ticket feat/<ticket-number>
-4. commit to  feat/<ticket-number>
-5. Raise PR from feat/<ticket-number> to release/0.0.9
-6. After PR is approved and merged
-7. Raise PR from release/0.0.9 to dev. Once PR is merged it will auto release the 0.0.9 version of SPI for dev code base
-8. After that raise PR from release/0.0.9 to main. Once PR is merged it will auto release the 0.0.9 version of SPI for prod codebase
+For detailed instructions, check out the [Release](docs/release.md).
 
 ## Updating & Using Postman Collection (TO BE ADDED)
 

--- a/docs/add_update_spi.md
+++ b/docs/add_update_spi.md
@@ -1,0 +1,56 @@
+#### 1. Modify the OpenAPI Specification
+
+#### 1.1 Update an Existing SPI
+- Edit the corresponding OpenAPI specification file to update the SPI.  
+  **Example:** Modify a parameter in the `tax-estimate` endpoint located in `spec/spi/open_tax.yml`.
+
+#### 1.2 Add a New SPI to an Existing OpenAPI Specification
+- Append the new SPI endpoint to the relevant OpenAPI specification file.  
+  **Example:** Add a new endpoint `check/taxability` in `spec/spi/open_tax.yml`.
+
+#### 1.3 Add a New SPI in a New OpenAPI Specification
+- Create a new OpenAPI specification file named `openapi_<capability_name>.yml` inside the `spec/spi/` directory.  
+  **Example:** `spec/spi/openapi_tax.yml`.
+- Update the [spec.config](spec.config) file to include the new file configuration.
+
+
+#### 2. Validate the OpenAPI Specification
+- Use the following command to validate a **specific** OpenAPI specification
+  ```bash
+  sh gradlew validateSpec_tax --warning-mode all --stacktrace
+  ```
+
+- Use the following command to validate all the OpenAPI specs:
+  ```bash
+  sh gradlew validateSpec  --warning-mode all --stacktrace  
+  ```
+
+#### 3. Generate the Bundled OpenAPI spec & related files
+- Each OpenAPI specification file in the spec/spi directory may reference other specification files (e.g., credentials.yml).
+  To generate a single bundled OpenAPI specification, use the following commands:
+  - for a specific openAPI spec:
+  ```bash
+  sh gradlew generateSpec_tax --warning-mode all --stacktrace
+  ```
+
+  - for all openAPI specs:
+  ```bash
+  sh gradlew generateSpec  --warning-mode all --stacktrace
+  ```
+
+- The generated output will include:
+  - Java Models
+  - Clients
+  - Markdown files
+
+- These files will be located in the `generated/<capability_name>` folder. **Example:** `generated/tax`
+
+#### 4. Generate SPI jar
+- To build the SPI jar for Java, use the following command:
+  ```bash
+  sh gradlew build
+  ```
+- The generated SPI jar will be located in the `./build/libs/` directory.
+
+#### 5. Update postman collection
+- Refer to the [Updating & Using Postman Collection (TO BE ADDED)](#updating--using-postman-collection-to-be-added) section to follow the steps to update the Postman collection.

--- a/docs/localsetup.md
+++ b/docs/localsetup.md
@@ -1,0 +1,17 @@
+## Setup with Mintlify
+
+- Chargebee uses Mintlify tool to host the SPI docs. Please follow the below steps to setup locally.
+
+#### 1. Install the Mintlify CLI
+- Install the Mintlify CLI globally using npm:
+
+```bash
+    npm i -g mintlify
+```
+
+#### 2. Run Local Development Server
+- For local preview of documentation run below command:
+
+```bash
+    mintlify dev
+```

--- a/docs/mintlify_files.md
+++ b/docs/mintlify_files.md
@@ -1,0 +1,52 @@
+#### Prerequisites
+
+#### 1. Install Node.js and npm
+- Node.js and npm are required to run the Mintlify CLI.    
+
+#### 2. Install Mintlify CLI
+- Install the Mintlify CLI globally to manage documentation and generate .mdx files:
+  ```bash
+  npm i -g mintlify
+  ```
+
+#### 1. Generate mdx files for SPI endpoint or new openAPISpec
+- Use the following command to create mdx files for the endpoints from the openAPI spec file you have added or made changes to
+  ```bash
+  npx @mintlify/scraping@latest openapi-file <path-to-openapi-file> -o api-reference
+  ```
+  **Example:**
+  ```bash
+  npx @mintlify/scraping@latest openapi-file ./spec/spi/openapi_tax.yml -o api-reference
+  ```
+
+#### 2. Add reference to generated endpoint mdx files in navigation section of mint.json
+
+#### 2.1 Locate Generated MDX Files
+After running the mdx files generation command, check the api-reference directory for new MDX files.
+
+#### 2.2 Update mint.json Navigation
+```json
+{
+  "navigation": [
+    {
+      "group": "API Reference",
+      "pages": [
+        // Existing pages
+        "api-reference/existing-endpoint",
+        
+        // Add your new endpoint MDX file here
+        "api-reference/new-endpoint-file"
+      ]
+    }
+  ]
+}
+```
+#### Note
+1. Don't use full file paths. Use relative paths.
+2. Don't include the .mdx extension.
+
+#### 3. Preview the changes locally
+- Run the following command to preview the changes locally
+  ```bash
+  mintlify dev
+  ```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,9 @@
+## Steps to follow release(Chargebee owned)
+1. Assume release is 0.0.9. (find release from git page release section)
+2. create a new branch called release/<release> so this would be release/0.0.9
+3. create new branch for ticket feat/<ticket-number>
+4. commit to  feat/<ticket-number>
+5. Raise PR from feat/<ticket-number> to release/0.0.9
+6. After PR is approved and merged
+7. Raise PR from release/0.0.9 to dev. Once PR is merged it will auto release the 0.0.9 version of SPI for dev code base
+8. After that raise PR from release/0.0.9 to main. Once PR is merged it will auto release the 0.0.9 version of SPI for prod codebase


### PR DESCRIPTION
Added the changes in the readme so that content related to partner spi should be shown and content related to chargebee internal use can be reffered to a different md file.